### PR TITLE
redirects to chevrotain.io

### DIFF
--- a/chevrotain/docs/index.html
+++ b/chevrotain/docs/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=https://chevrotain.io/docs/" />
+</head>
+<body>
+
+</body>
+</html>

--- a/chevrotain/index.html
+++ b/chevrotain/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=https://chevrotain.io/docs/" />
+</head>
+<body>
+
+</body>
+</html>

--- a/chevrotain/performance/index.html
+++ b/chevrotain/performance/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=https://chevrotain.io/performance/" />
+</head>
+<body>
+
+</body>
+</html>

--- a/chevrotain/playground/index.html
+++ b/chevrotain/playground/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=https://chevrotain.io/playground/" />
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
These redirects are needed to keep previous URLs "alive"
Once the Chevrotain project moves to another organization.

sap.github.io/chevrotain --> chevrotain.io/docs/
sap.github.io/chevrotain/docs/ --> chevrotain.io/docs/
sap.github.io/chevrotain/performance --> chevrotain.io/performance/
sap.github.io/chevrotain/playground --> chevrotain.io/playground/